### PR TITLE
Dockerfile.rhel: workaround OSBS imagebuilder bug

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,6 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 
-ARG ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
+ENV ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
 COPY . ${ALERTMANAGER_GOPATH}
 RUN cd ${ALERTMANAGER_GOPATH} && \
     make build
@@ -11,7 +11,7 @@ LABEL io.k8s.display-name="OpenShift Prometheus Alert Manager" \
       io.openshift.tags="prometheus,monitoring" \
       maintainer="OpenShift Development <dev@lists.openshift.redhat.com>"
 
-ARG ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
+ENV ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
 COPY --from=builder ${ALERTMANAGER_GOPATH}/amtool                       /bin/amtool
 COPY --from=builder ${ALERTMANAGER_GOPATH}/alertmanager                 /bin/alertmanager
 COPY --from=builder ${ALERTMANAGER_GOPATH}/examples/ha/alertmanager.yml /etc/alertmanager/alertmanager.yml


### PR DESCRIPTION
downstream imagebuilder doesn't understand ARG yet.
ARGs used here are simply empty in the build.
I've built an updated imagebuilder for OSBS but it needs to be incorporated into the monthly release.
In the meantime can this just use ENV?