### PR TITLE
Install promu package for OCP multistage builds

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,9 +1,12 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 
 ENV ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
+ENV BUILD_PROMU=false
 COPY . ${ALERTMANAGER_GOPATH}
 RUN cd ${ALERTMANAGER_GOPATH} && \
-    make build
+    yum install -y prometheus-promu && \
+    make build && \
+    yum clean all
 
 FROM  registry.svc.ci.openshift.org/ocp/4.0:base
 LABEL io.k8s.display-name="OpenShift Prometheus Alert Manager" \


### PR DESCRIPTION
Similar to https://github.com/openshift/prometheus/pull/21:

> We need `promu` to build Prometheus but we should use the promu package instead of the upstream version because 1) we're not allowed to download stuff from the outside and 2) this promu version generates proper binaries for OCP (eg dynamically linked with glibc).

cc @sosiouxme 