### PR TITLE
Dockerfile.rhel: work around correct imagebuilder bug

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,6 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 
-ENV ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
+ARG ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
 COPY . ${ALERTMANAGER_GOPATH}
 RUN cd ${ALERTMANAGER_GOPATH} && \
     make build
@@ -11,12 +11,13 @@ LABEL io.k8s.display-name="OpenShift Prometheus Alert Manager" \
       io.openshift.tags="prometheus,monitoring" \
       maintainer="OpenShift Development <dev@lists.openshift.redhat.com>"
 
-ENV ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
+ARG ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
 COPY --from=builder ${ALERTMANAGER_GOPATH}/amtool                       /bin/amtool
 COPY --from=builder ${ALERTMANAGER_GOPATH}/alertmanager                 /bin/alertmanager
 COPY --from=builder ${ALERTMANAGER_GOPATH}/examples/ha/alertmanager.yml /etc/alertmanager/alertmanager.yml
 
 EXPOSE     9093
+RUN mkdir -p /alertmanager
 VOLUME     [ "/alertmanager" ]
 WORKDIR    /etc/alertmanager
 ENTRYPOINT [ "/bin/alertmanager" ]


### PR DESCRIPTION
https://github.com/openshift/prometheus-alertmanager/pull/15 was a red herring, sorry.

The build problem I saw was due to https://github.com/openshift/imagebuilder/issues/87
When a VOLUME is specified, imagebuilder doesn't create it like docker does, and RUN breaks later.
The workaround is to create it explicitly before VOLUME.

I was mistaken previously in thinking imagebuilder didn't understand ARG.
There was just one situation where that was true, which was not relevant here:
https://github.com/openshift/imagebuilder/pull/102 ARG before FROM