### PR TITLE
Makefile promu fix

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -10,14 +10,13 @@ build:
           path: ./cmd/alertmanager
         - name: amtool
           path: ./cmd/amtool
-    flags: -a -tags netgo
+    flags: -mod vendor -a -tags netgo
     ldflags: |
-        -s
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Revision={{.Revision}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Branch={{.Branch}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
+        -X github.com/prometheus/common/version.Version={{.Version}}
+        -X github.com/prometheus/common/version.Revision={{.Revision}}
+        -X github.com/prometheus/common/version.Branch={{.Branch}}
+        -X github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
+        -X github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
 tarball:
     files:
         - examples/ha/alertmanager.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 
 ARG ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
 COPY . ${ALERTMANAGER_GOPATH}

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
 
 ARG ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
 ARG BUILD_PROMU=false

--- a/Makefile.common
+++ b/Makefile.common
@@ -29,7 +29,7 @@ GO           ?= go
 GOFMT        ?= $(GO)fmt
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 ifeq ($(BUILD_PROMU),false)
-	PROMU        := promu
+	PROMU        := $(shell which promu)
 else
 	PROMU        := $(FIRST_GOPATH)/bin/promu
 endif
@@ -199,11 +199,15 @@ common-docker-tag-latest:
 promu: $(PROMU)
 
 $(PROMU):
+ifeq ($(BUILD_PROMU),false)
+	@echo "using installed promu: $(PROMU)"
+else
 	$(eval PROMU_TMP := $(shell mktemp -d))
 	curl -s -L $(PROMU_URL) | tar -xvzf - -C $(PROMU_TMP)
 	mkdir -p $(FIRST_GOPATH)/bin
 	cp $(PROMU_TMP)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM)/promu $(FIRST_GOPATH)/bin/promu
 	rm -r $(PROMU_TMP)
+endif
 
 .PHONY: proto
 proto:


### PR DESCRIPTION
The update to 0.16.0 included some changes to Makefile.common that caused a circular dependency warning and download promu when BUILD_PROMU is set to false.  This should fix that, and also upgrade to use go 1.11 which is available now.