### PR TITLE
unify Dockerfile naming and bring in upstream Dockerfile

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,14 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
+WORKDIR /go/src/github.com/prometheus/alertmanager
+COPY . .
+RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make build
 
-ARG ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
-ARG BUILD_PROMU=false
-COPY . ${ALERTMANAGER_GOPATH}
-RUN cd ${ALERTMANAGER_GOPATH} && \
-    yum install -y prometheus-promu && \
-    make build && \
-    yum clean all
-
-FROM  registry.svc.ci.openshift.org/ocp/4.0:base
+FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 LABEL io.k8s.display-name="OpenShift Prometheus Alert Manager" \
       io.k8s.description="Prometheus Alert Manager" \
       io.openshift.tags="prometheus,monitoring" \


### PR DESCRIPTION
Similar to https://github.com/openshift/prometheus/pull/34

- `mv Dockerfile.rhel Dockerfile.ocp`
- Bring in upstream Dockerfile (just to keep it clean)
- unify `Dockerfile.ocp` structure with one from openshift/prometheus

CI will fail as it needs openshift/release#4235 first.