### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,5 @@
 # FROM directives are overriden by CI system (both Prow CI and OSBS)
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/prometheus/alertmanager
 COPY . .
 RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make build
@@ -8,7 +8,8 @@ FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 LABEL io.k8s.display-name="OpenShift Prometheus Alert Manager" \
       io.k8s.description="Prometheus Alert Manager" \
       io.openshift.tags="prometheus,monitoring" \
-      maintainer="OpenShift Development <dev@lists.openshift.redhat.com>"
+      summary="Prometheus Alert Manager" \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
 
 ARG ALERTMANAGER_GOPATH=/go/src/github.com/prometheus/alertmanager
 COPY --from=builder ${ALERTMANAGER_GOPATH}/amtool                       /bin/amtool


### PR DESCRIPTION
- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value
- explicit golang 1.14 usage

/cc @openshift/openshift-team-monitoring