### PR TITLE
OCPBUGS-33686: Dockerfile.ocp: use common-build target

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -2,7 +2,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/prometheus/alertmanager
 COPY . .
-RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make build
+RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make common-build
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 LABEL io.k8s.display-name="OpenShift Prometheus Alert Manager" \


### PR DESCRIPTION
The alertmanager Makefile introduced a build target recently, so `make build` no longer resolves to `make common-build` like before.

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->
