### PR TITLE
Updating golang-github-prometheus-alertmanager-container image to be consistent with ART for 4.20 Reconciling with https://github.com/openshift/ocp-build-data/tree/dfb5c7d531490cfdc61a3b88bc533702b9624997/images/golang-github-prometheus-alertmanager.yml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.20

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 !/notify/email/testdata/*.yml
 !/doc/examples/simple.yml
 !/circle.yml
-!/.travis.yml
+!.travis.yml
 !/.promu.yml
 !/api/v2/openapi.yaml
 !.github/workflows/*.yml

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,10 +1,10 @@
 # FROM directives are overriden by CI system (both Prow CI and OSBS)
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/prometheus/alertmanager
 COPY . .
 RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make common-build
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 LABEL io.k8s.display-name="OpenShift Prometheus Alert Manager" \
       io.k8s.description="Prometheus Alert Manager" \
       io.openshift.tags="prometheus,monitoring" \


### PR DESCRIPTION
<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->
