### PR TITLE
OCPBUGS-59400: Include go-verify-deps expected files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 !/.promu.yml
 !/api/v2/openapi.yaml
 !.github/workflows/*.yml
+
+# Include CI/build configuration files in vendor directory
+!vendor/**/*.yml
+!vendor/**/*.yaml


### PR DESCRIPTION
This PR changes the gitignore so the files expected in the vendor
directory by go-verify-deps [1] step are tracked.

[1] https://github.com/openshift/release/pull/64097/

<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->
