### PR TITLE
OCPBUGS-99435: embed tzdata in the alertmanager binary

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -13,6 +13,7 @@ build:
     tags:
         all:
             - netgo
+            - timetzdata
         windows: []
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}


### PR DESCRIPTION
<!--
    OpenShift: Don't forget to run `./scripts/rh-manifest.sh` from the
    repository root, and check-in the updated `rh-manifest.txt` file if
    necessary.
-->
