### PR TITLE
OCPBUGS-100352: Set testdata CA expiry to 20 years from issue date (#4112)

### DIFF
--- a/cluster/testdata/certs/ca.pem
+++ b/cluster/testdata/certs/ca.pem
@@ -1,8 +1,66 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            7a:d7:1c:f3:22:da:b1:20:31:bf:25:16:b6:04:d5:29:1e:a3:7c:12
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=AU, ST=Victoria, L=Melbourne, O=massl, OU=VIC, CN=massl
+        Validity
+            Not Before: Nov  6 22:02:17 2024 GMT
+            Not After : Nov  1 22:02:17 2044 GMT
+        Subject: C=AU, ST=Victoria, L=Melbourne, O=massl, OU=VIC, CN=massl
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:58:c3:8c:a5:46:c2:5c:a2:b8:a4:d2:1d:cd:
+                    50:a6:86:4f:5f:d7:5b:83:05:3f:f7:5d:77:72:d2:
+                    3c:53:f6:70:31:62:e9:9d:9e:1f:ff:35:69:7f:82:
+                    d6:e5:fa:0c:f7:34:84:50:63:e2:c8:97:bf:35:a4:
+                    d9:50:e5:e4:44:14:88:43:5d:d0:ae:82:b8:38:9d:
+                    57:19:a7:10:2a:94:f1:7b:00:9b:0a:11:12:64:47:
+                    ca:58:48:67:3f:f6:3b:05:87:38:cf:52:e2:e8:39:
+                    31:87:84:c8:12:51:f0:39:57:ba:da:36:e1:36:7c:
+                    d8:96:be:1e:be:64:ae:8a:e2:2d:01:cf:2e:84:46:
+                    31:9d:c4:e1:3f:39:87:11:63:d7:2b:0f:02:14:d8:
+                    71:09:26:2c:8d:b6:fb:d9:40:08:86:dd:24:9c:c1:
+                    d0:ed:55:c1:5f:55:6e:b8:bd:2b:a2:52:41:89:3a:
+                    02:bd:af:88:e8:28:c6:d1:ce:aa:7e:2f:7f:05:c3:
+                    ec:b9:6e:9c:36:39:90:9f:04:e0:e9:26:92:a0:63:
+                    bf:e7:38:1b:c4:18:32:f4:c6:50:12:8b:7c:f1:dd:
+                    53:d9:71:fa:ac:10:0d:62:c7:e8:8e:fc:82:5e:ec:
+                    ad:5a:78:f4:e2:6b:dd:01:6c:26:16:1d:21:86:af:
+                    a7:c5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier:
+                77:80:D3:12:52:AA:EA:09:C6:60:32:59:80:9B:C2:FB:87:E5:AD:90
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        92:f2:a4:8f:7d:04:f1:7e:08:b0:6b:3e:0c:b9:88:29:18:b6:
+        ce:88:4e:84:b0:10:8b:ca:b5:d6:6a:fb:12:52:14:f2:4e:01:
+        bb:b3:8b:a0:b4:65:d9:fd:d4:c7:6b:44:54:3a:e5:5b:c9:0e:
+        bd:3c:3b:f7:41:0a:67:1d:5a:21:32:7c:42:3b:b1:37:b4:c0:
+        78:07:4b:ae:e2:18:77:90:85:33:70:46:20:61:1a:7a:67:38:
+        0a:cf:fc:1c:bd:d2:c6:1a:0e:09:5a:d5:36:74:8a:8e:66:0f:
+        1f:47:69:7a:17:a7:d3:bf:74:40:85:3f:80:a2:53:00:2a:65:
+        3c:3f:ca:44:d9:ec:71:cf:17:4e:3d:b0:1e:5e:e8:73:ab:0a:
+        27:95:02:88:2b:b0:46:9a:4d:a4:7d:05:ba:df:4c:e5:65:d3:
+        2b:12:fd:17:74:51:f2:bb:d1:0e:32:8c:e9:ee:42:5c:d7:3c:
+        85:60:f0:1a:52:fc:11:31:e1:12:8c:c9:a0:1f:1f:52:7e:d9:
+        1e:a0:c7:f7:48:05:9d:dc:f5:c1:59:5a:9b:e7:bd:a3:37:54:
+        8a:42:c7:10:d7:51:19:99:e2:e7:d3:56:66:18:4a:d0:d1:f6:
+        25:1d:c9:f9:48:60:43:cc:6f:9c:ba:95:03:3e:a0:5a:ad:26:
+        d8:ce:4c:4a
 -----BEGIN CERTIFICATE-----
 MIIDlDCCAnygAwIBAgIUetcc8yLasSAxvyUWtgTVKR6jfBIwDQYJKoZIhvcNAQEL
 BQAwYjELMAkGA1UEBhMCQVUxETAPBgNVBAgTCFZpY3RvcmlhMRIwEAYDVQQHEwlN
 ZWxib3VybmUxDjAMBgNVBAoTBW1hc3NsMQwwCgYDVQQLEwNWSUMxDjAMBgNVBAMT
-BW1hc3NsMB4XDTIxMDUwNTE2MTYwMFoXDTI2MDUwNDE2MTYwMFowYjELMAkGA1UE
+BW1hc3NsMB4XDTI0MTEwNjIyMDIxN1oXDTQ0MTEwMTIyMDIxN1owYjELMAkGA1UE
 BhMCQVUxETAPBgNVBAgTCFZpY3RvcmlhMRIwEAYDVQQHEwlNZWxib3VybmUxDjAM
 BgNVBAoTBW1hc3NsMQwwCgYDVQQLEwNWSUMxDjAMBgNVBAMTBW1hc3NsMIIBIjAN
 BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuljDjKVGwlyiuKTSHc1QpoZPX9db
@@ -12,11 +70,11 @@ NnzYlr4evmSuiuItAc8uhEYxncThPzmHEWPXKw8CFNhxCSYsjbb72UAIht0knMHQ
 7VXBX1VuuL0rolJBiToCva+I6CjG0c6qfi9/BcPsuW6cNjmQnwTg6SaSoGO/5zgb
 xBgy9MZQEot88d1T2XH6rBANYsfojvyCXuytWnj04mvdAWwmFh0hhq+nxQIDAQAB
 o0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU
-d4DTElKq6gnGYDJZgJvC+4flrZAwDQYJKoZIhvcNAQELBQADggEBAHYaMxcyVdFP
-QZJHDP6x+A1hHeZy/kaL2VPzUIOgt3ONEvjhsJblFjLaTWwXFJwxVHXRsQjqrURj
-dD2VIkMbCJM4WN8odi6PdHscL0DwHKzwZDapQxsOUYcPBbR2EsBPRyWSoJmBnEyZ
-0TANtyUcZNWc7/C4GG66SWypu1YRdtcaDiEOVkdetGWuo5bw1J7B7isQ4J4a3+Qn
-iTKId/7wWBY95JS2xJuOeEjk/ty74ruSapk2Aip1GRSRXMDtD0XeO5dpxc6eIU3C
-jbRpUGqCdSAfzxQTlxQAMEKdgRlt7lzMFX/PAXagDOMC9D/6APn5fquEV2d9wMWs
-0N9UCwKftAU=
+d4DTElKq6gnGYDJZgJvC+4flrZAwDQYJKoZIhvcNAQELBQADggEBAJLypI99BPF+
+CLBrPgy5iCkYts6IToSwEIvKtdZq+xJSFPJOAbuzi6C0Zdn91MdrRFQ65VvJDr08
+O/dBCmcdWiEyfEI7sTe0wHgHS67iGHeQhTNwRiBhGnpnOArP/By90sYaDgla1TZ0
+io5mDx9HaXoXp9O/dECFP4CiUwAqZTw/ykTZ7HHPF049sB5e6HOrCieVAogrsEaa
+TaR9BbrfTOVl0ysS/Rd0UfK70Q4yjOnuQlzXPIVg8BpS/BEx4RKMyaAfH1J+2R6g
+x/dIBZ3c9cFZWpvnvaM3VIpCxxDXURmZ4ufTVmYYStDR9iUdyflIYEPMb5y6lQM+
+oFqtJtjOTEo=
 -----END CERTIFICATE-----

--- a/examples/ha/tls/certs/ca.pem
+++ b/examples/ha/tls/certs/ca.pem
@@ -1,8 +1,66 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            7a:d7:1c:f3:22:da:b1:20:31:bf:25:16:b6:04:d5:29:1e:a3:7c:12
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=AU, ST=Victoria, L=Melbourne, O=massl, OU=VIC, CN=massl
+        Validity
+            Not Before: Nov  6 22:02:17 2024 GMT
+            Not After : Nov  1 22:02:17 2044 GMT
+        Subject: C=AU, ST=Victoria, L=Melbourne, O=massl, OU=VIC, CN=massl
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:ba:58:c3:8c:a5:46:c2:5c:a2:b8:a4:d2:1d:cd:
+                    50:a6:86:4f:5f:d7:5b:83:05:3f:f7:5d:77:72:d2:
+                    3c:53:f6:70:31:62:e9:9d:9e:1f:ff:35:69:7f:82:
+                    d6:e5:fa:0c:f7:34:84:50:63:e2:c8:97:bf:35:a4:
+                    d9:50:e5:e4:44:14:88:43:5d:d0:ae:82:b8:38:9d:
+                    57:19:a7:10:2a:94:f1:7b:00:9b:0a:11:12:64:47:
+                    ca:58:48:67:3f:f6:3b:05:87:38:cf:52:e2:e8:39:
+                    31:87:84:c8:12:51:f0:39:57:ba:da:36:e1:36:7c:
+                    d8:96:be:1e:be:64:ae:8a:e2:2d:01:cf:2e:84:46:
+                    31:9d:c4:e1:3f:39:87:11:63:d7:2b:0f:02:14:d8:
+                    71:09:26:2c:8d:b6:fb:d9:40:08:86:dd:24:9c:c1:
+                    d0:ed:55:c1:5f:55:6e:b8:bd:2b:a2:52:41:89:3a:
+                    02:bd:af:88:e8:28:c6:d1:ce:aa:7e:2f:7f:05:c3:
+                    ec:b9:6e:9c:36:39:90:9f:04:e0:e9:26:92:a0:63:
+                    bf:e7:38:1b:c4:18:32:f4:c6:50:12:8b:7c:f1:dd:
+                    53:d9:71:fa:ac:10:0d:62:c7:e8:8e:fc:82:5e:ec:
+                    ad:5a:78:f4:e2:6b:dd:01:6c:26:16:1d:21:86:af:
+                    a7:c5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier:
+                77:80:D3:12:52:AA:EA:09:C6:60:32:59:80:9B:C2:FB:87:E5:AD:90
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        92:f2:a4:8f:7d:04:f1:7e:08:b0:6b:3e:0c:b9:88:29:18:b6:
+        ce:88:4e:84:b0:10:8b:ca:b5:d6:6a:fb:12:52:14:f2:4e:01:
+        bb:b3:8b:a0:b4:65:d9:fd:d4:c7:6b:44:54:3a:e5:5b:c9:0e:
+        bd:3c:3b:f7:41:0a:67:1d:5a:21:32:7c:42:3b:b1:37:b4:c0:
+        78:07:4b:ae:e2:18:77:90:85:33:70:46:20:61:1a:7a:67:38:
+        0a:cf:fc:1c:bd:d2:c6:1a:0e:09:5a:d5:36:74:8a:8e:66:0f:
+        1f:47:69:7a:17:a7:d3:bf:74:40:85:3f:80:a2:53:00:2a:65:
+        3c:3f:ca:44:d9:ec:71:cf:17:4e:3d:b0:1e:5e:e8:73:ab:0a:
+        27:95:02:88:2b:b0:46:9a:4d:a4:7d:05:ba:df:4c:e5:65:d3:
+        2b:12:fd:17:74:51:f2:bb:d1:0e:32:8c:e9:ee:42:5c:d7:3c:
+        85:60:f0:1a:52:fc:11:31:e1:12:8c:c9:a0:1f:1f:52:7e:d9:
+        1e:a0:c7:f7:48:05:9d:dc:f5:c1:59:5a:9b:e7:bd:a3:37:54:
+        8a:42:c7:10:d7:51:19:99:e2:e7:d3:56:66:18:4a:d0:d1:f6:
+        25:1d:c9:f9:48:60:43:cc:6f:9c:ba:95:03:3e:a0:5a:ad:26:
+        d8:ce:4c:4a
 -----BEGIN CERTIFICATE-----
 MIIDlDCCAnygAwIBAgIUetcc8yLasSAxvyUWtgTVKR6jfBIwDQYJKoZIhvcNAQEL
 BQAwYjELMAkGA1UEBhMCQVUxETAPBgNVBAgTCFZpY3RvcmlhMRIwEAYDVQQHEwlN
 ZWxib3VybmUxDjAMBgNVBAoTBW1hc3NsMQwwCgYDVQQLEwNWSUMxDjAMBgNVBAMT
-BW1hc3NsMB4XDTIxMDUwNTE2MTYwMFoXDTI2MDUwNDE2MTYwMFowYjELMAkGA1UE
+BW1hc3NsMB4XDTI0MTEwNjIyMDIxN1oXDTQ0MTEwMTIyMDIxN1owYjELMAkGA1UE
 BhMCQVUxETAPBgNVBAgTCFZpY3RvcmlhMRIwEAYDVQQHEwlNZWxib3VybmUxDjAM
 BgNVBAoTBW1hc3NsMQwwCgYDVQQLEwNWSUMxDjAMBgNVBAMTBW1hc3NsMIIBIjAN
 BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuljDjKVGwlyiuKTSHc1QpoZPX9db
@@ -12,11 +70,11 @@ NnzYlr4evmSuiuItAc8uhEYxncThPzmHEWPXKw8CFNhxCSYsjbb72UAIht0knMHQ
 7VXBX1VuuL0rolJBiToCva+I6CjG0c6qfi9/BcPsuW6cNjmQnwTg6SaSoGO/5zgb
 xBgy9MZQEot88d1T2XH6rBANYsfojvyCXuytWnj04mvdAWwmFh0hhq+nxQIDAQAB
 o0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU
-d4DTElKq6gnGYDJZgJvC+4flrZAwDQYJKoZIhvcNAQELBQADggEBAHYaMxcyVdFP
-QZJHDP6x+A1hHeZy/kaL2VPzUIOgt3ONEvjhsJblFjLaTWwXFJwxVHXRsQjqrURj
-dD2VIkMbCJM4WN8odi6PdHscL0DwHKzwZDapQxsOUYcPBbR2EsBPRyWSoJmBnEyZ
-0TANtyUcZNWc7/C4GG66SWypu1YRdtcaDiEOVkdetGWuo5bw1J7B7isQ4J4a3+Qn
-iTKId/7wWBY95JS2xJuOeEjk/ty74ruSapk2Aip1GRSRXMDtD0XeO5dpxc6eIU3C
-jbRpUGqCdSAfzxQTlxQAMEKdgRlt7lzMFX/PAXagDOMC9D/6APn5fquEV2d9wMWs
-0N9UCwKftAU=
+d4DTElKq6gnGYDJZgJvC+4flrZAwDQYJKoZIhvcNAQELBQADggEBAJLypI99BPF+
+CLBrPgy5iCkYts6IToSwEIvKtdZq+xJSFPJOAbuzi6C0Zdn91MdrRFQ65VvJDr08
+O/dBCmcdWiEyfEI7sTe0wHgHS67iGHeQhTNwRiBhGnpnOArP/By90sYaDgla1TZ0
+io5mDx9HaXoXp9O/dECFP4CiUwAqZTw/ykTZ7HHPF049sB5e6HOrCieVAogrsEaa
+TaR9BbrfTOVl0ysS/Rd0UfK70Q4yjOnuQlzXPIVg8BpS/BEx4RKMyaAfH1J+2R6g
+x/dIBZ3c9cFZWpvnvaM3VIpCxxDXURmZ4ufTVmYYStDR9iUdyflIYEPMb5y6lQM+
+oFqtJtjOTEo=
 -----END CERTIFICATE-----


### PR DESCRIPTION
Also add human-readable x509 text format.
